### PR TITLE
fix(meowhq-istio-gateway): reduce input values

### DIFF
--- a/charts/meowhq-istio-gateway/README.md
+++ b/charts/meowhq-istio-gateway/README.md
@@ -75,7 +75,7 @@ This section provides configuration details for the official Istio Ingress Gatew
 
 ### Basic Settings
 
-- `gateway.name`: Name of the gateway deployment
+- `gateway.name`: Name of the gateway deployment. default value is empty string and it uses release.name with dropping istio- prefix if exists
 - `gateway.imagePullSecrets`: Image pull secrets configuration (default: empty array)
 - `gateway.revision`: Istio revision
 - `gateway.labels.app`: App label value (default: null). it will be automatically generated and set from gateway.name unless you set the custom value

--- a/charts/meowhq-istio-gateway/README.md
+++ b/charts/meowhq-istio-gateway/README.md
@@ -75,7 +75,7 @@ This section provides configuration details for the official Istio Ingress Gatew
 
 ### Basic Settings
 
-- `gateway.name`: Name of the gateway deployment. default value is empty string and it uses release.name with dropping istio- prefix if exists
+- `gateway.name`: Name of the gateway. If not set, it defaults to the release name with the 'istio-' prefix removed if it exists.
 - `gateway.imagePullSecrets`: Image pull secrets configuration (default: empty array)
 - `gateway.revision`: Istio revision
 - `gateway.labels.app`: App label value (default: null). it will be automatically generated and set from gateway.name unless you set the custom value

--- a/charts/meowhq-istio-gateway/templates/_helpers.tpl
+++ b/charts/meowhq-istio-gateway/templates/_helpers.tpl
@@ -20,3 +20,11 @@
 {{- $dict := include "gatewaySelectorLabel" . | fromYaml -}}
 {{ $dict.istio }}
 {{- end -}}
+
+{{/*
+  use the istioGatewayName same as gatewaySelectorLabelIstio convention.
+  so, if the release name is istio-ingressgateway, then the istioGateway.name will be ingressgateway by default if istioGateway.name is not set in values.yaml
+*/}}
+{{- define "istioGatewayName" -}}
+{{ .Values.istioGateway.name | default (include "gatewaySelectorLabelIstio" .) }}
+{{- end -}}

--- a/charts/meowhq-istio-gateway/templates/ingress-gateway.yaml
+++ b/charts/meowhq-istio-gateway/templates/ingress-gateway.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.istio.io/{{ .Values.global.istioGateway.apiVersion }}
 kind: Gateway
 metadata:
-  name: {{ .Values.istioGateway.name }}
+  name: {{ include "istioGatewayName" . }}
   namespace: {{ .Values.global.istioGateway.namespace }}
 spec:
   selector:

--- a/charts/meowhq-istio-gateway/tests/default-values-gateway_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/default-values-gateway_test.yaml
@@ -14,7 +14,7 @@ tests:
   - containsDocument:
       apiVersion: networking.istio.io/v1
       kind: Gateway
-      name: ingress-gateway
+      name: ingressgateway
       namespace: istio-system
   - equal:
       path: spec
@@ -31,6 +31,28 @@ tests:
             credentialName: gateway-tls
           hosts:
             - '*'
+
+- it: render Gateway name with release name.
+  template: ingress-gateway.yaml
+  release:
+    name: "my-custom-ingressgateway"
+  asserts:
+  - containsDocument:
+      apiVersion: networking.istio.io/v1
+      kind: Gateway
+      name: my-custom-ingressgateway
+      namespace: istio-system
+
+- it: render Gateway name with release name. drop istio- prefix if exists
+  template: ingress-gateway.yaml
+  release:
+    name: "istio-my-custom-ingressgateway"
+  asserts:
+  - containsDocument:
+      apiVersion: networking.istio.io/v1
+      kind: Gateway
+      name: my-custom-ingressgateway
+      namespace: istio-system
 
 - it: should not render the cross-network-gateway Gateway by default
   template: multicluster/cross-network-gateway.yaml

--- a/charts/meowhq-istio-gateway/tests/default-vaules-subchart-deployment_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/default-vaules-subchart-deployment_test.yaml
@@ -2,7 +2,7 @@ suite: Istio Gateway subchart test - Deployment for cross-network-gateway config
 templates:
   - charts/* # this includes all the templates in the subchart
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 tests:
 - it: should render deployment with default values

--- a/charts/meowhq-istio-gateway/tests/default-vaules-subchart-service_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/default-vaules-subchart-service_test.yaml
@@ -2,7 +2,7 @@ suite: Istio Gateway subchart test - Service for cross-network-gateway configura
 templates:
   - charts/* # this includes all the templates in the subchart
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 tests:
 - it: should render service with default values

--- a/charts/meowhq-istio-gateway/tests/ingress-gateway-additional-service-ports_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/ingress-gateway-additional-service-ports_test.yaml
@@ -3,7 +3,7 @@ templates:
   - ingress-gateway.yaml
   - charts/* # this includes all the templates in the subchart
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 values:
   - values/ingress-gateway-additional-service-ports-values.yaml

--- a/charts/meowhq-istio-gateway/tests/ingress-gateway-additionalServers_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/ingress-gateway-additionalServers_test.yaml
@@ -5,7 +5,7 @@ templates:
   - multicluster/istiod-gateway.yaml
   - multicluster/istiod-virtualservice.yaml
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 values:
   - values/ingress-gateway-additionalServers-values.yaml

--- a/charts/meowhq-istio-gateway/tests/ingress-gateway_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/ingress-gateway_test.yaml
@@ -5,7 +5,7 @@ templates:
   - multicluster/istiod-gateway.yaml
   - multicluster/istiod-virtualservice.yaml
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 values:
   - values/ingress-gateway-values.yaml

--- a/charts/meowhq-istio-gateway/tests/internal-ingress-gateway_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/internal-ingress-gateway_test.yaml
@@ -5,7 +5,7 @@ templates:
   - multicluster/istiod-gateway.yaml
   - multicluster/istiod-virtualservice.yaml
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 values:
   - values/internal-ingress-gateway-values.yaml

--- a/charts/meowhq-istio-gateway/tests/istio-label-selector_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/istio-label-selector_test.yaml
@@ -19,6 +19,16 @@ tests:
       path: spec.selector.istio
       value: my-ingressgateway
 
+- it: render istio selector label from gateway.name and trim "istio-" prefix from name for ingress-gateway
+  set:
+    gateway:
+      name: istio-another-ingressgateway
+  template: ingress-gateway.yaml
+  asserts:
+  - equal:
+      path: spec.selector.istio
+      value: another-ingressgateway
+
 - it: render istio selector label from release name after trim "istio-" as expected for cross-network-gateway
   set:
     multicluster:

--- a/charts/meowhq-istio-gateway/tests/multicluster-gateway-subchart-deployment_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/multicluster-gateway-subchart-deployment_test.yaml
@@ -2,7 +2,7 @@ suite: Istio Gateway subchart test - Deployment for cross-network-gateway config
 templates:
   - charts/* # this includes all the templates in the subchart
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 values:
   - values/multicluster-values.yaml

--- a/charts/meowhq-istio-gateway/tests/multicluster-gateway-subchart-service_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/multicluster-gateway-subchart-service_test.yaml
@@ -2,7 +2,7 @@ suite: Istio Gateway subchart test - Service for cross-network-gateway configura
 templates:
   - charts/* # this includes all the templates in the subchart
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 values:
   - values/multicluster-values.yaml

--- a/charts/meowhq-istio-gateway/tests/multicluster-gateway_test.yaml
+++ b/charts/meowhq-istio-gateway/tests/multicluster-gateway_test.yaml
@@ -5,7 +5,7 @@ templates:
   - multicluster/istiod-gateway.yaml
   - multicluster/istiod-virtualservice.yaml
 release:
-  name: "istio-gateway"
+  name: "istio-ingressgateway"
   namespace: "istio-system"
 values:
   - values/multicluster-values.yaml

--- a/charts/meowhq-istio-gateway/tests/values/ingress-gateway-additionalServers-values.yaml
+++ b/charts/meowhq-istio-gateway/tests/values/ingress-gateway-additionalServers-values.yaml
@@ -2,6 +2,7 @@
 # istio Gateway resources configuration - networking.istio.io/Gateway
 # =============================================================================
 istioGateway:
+  name: ingress-gateway
   https:
     credentialName: my-tls-secret
   additionalServers:

--- a/charts/meowhq-istio-gateway/values.yaml
+++ b/charts/meowhq-istio-gateway/values.yaml
@@ -55,7 +55,7 @@ multicluster:
 #   - cross-network-gateway
 # =============================================================================
 gateway:
-  name: istio-ingressgateway
+  name: ""  # set the default value to empty string to avoid null pointer in helper and use the default value from the chart helper
   revision: "default"
   imagePullSecrets: []
   # gateway.labels.app/istio should be initialized with null as default to avoid null pointer in helper

--- a/charts/meowhq-istio-gateway/values.yaml
+++ b/charts/meowhq-istio-gateway/values.yaml
@@ -16,7 +16,7 @@ global:
 
 istioGateway:
   enabled: true
-  name: ingress-gateway
+  name: ""
   # it enables https port 443 with TLS mode SIMPLE by default
   https:
     tlsMode: SIMPLE


### PR DESCRIPTION
- set gateway labels null. so it uses generated values in istio-gateway chart
  - also, get istio-gateway chart's istio label value to set selector in the gateway
  - so, no need to set labels
- set empty string to istioGateway.name as default value. and use same istio label value for gateway name.
